### PR TITLE
Replaced os.path.join with '/' join to avoid invalid XPaths on Windows

### DIFF
--- a/Notebooks/solutions/tixi_exercise_solution.ipynb
+++ b/Notebooks/solutions/tixi_exercise_solution.ipynb
@@ -21,7 +21,6 @@
    },
    "outputs": [],
    "source": [
-    "import os\n",
     "from tixi3 import tixi3wrapper\n",
     "tixi_h = tixi3wrapper.Tixi3()"
    ]
@@ -64,15 +63,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# airport_xpath = '/cpacs/airports/airport[1]'\n",
+    "#airport_xpath = '/cpacs/airports/airport[@uID=\"FRA\"]'\n",
     "airport_xpath = tixi_h.uIDGetXPath('FRA')\n",
     "\n",
-    "airport_name = tixi_h.getTextElement(os.path.join(airport_xpath,'name'))\n",
-    "positionNorth = tixi_h.getDoubleElement(os.path.join(airport_xpath,'positionNorth'))\n",
-    "positionEast = tixi_h.getDoubleElement(os.path.join(airport_xpath,'positionEast'))\n",
+    "airport_name = tixi_h.getTextElement('/'.join((airport_xpath, 'name')))\n",
+    "positionNorth = tixi_h.getDoubleElement('/'.join((airport_xpath, 'positionNorth')))\n",
+    "positionEast = tixi_h.getDoubleElement('/'.join((airport_xpath, 'positionEast')))\n",
     "\n",
-    "print('Name: %s\\nPosition North: %.3f\\nPosition East: %.3f'\n",
-    "        %(airport_name, positionNorth, positionEast))"
+    "print('Name: %s\\nPosition North: %.3f\\nPosition East: %.3f' % (airport_name, positionNorth, positionEast))"
    ]
   },
   {
@@ -90,15 +88,16 @@
    },
    "outputs": [],
    "source": [
-    "root_xpath = os.path.join(tixi_h.uIDGetXPath('FRAtoEWRID'),'flightPath')\n",
+    "root_xpath = '/'.join((tixi_h.uIDGetXPath('FRAtoEWRID'),'flightPath'))\n",
     "\n",
-    "vector_size = tixi_h.getVectorSize(os.path.join(root_xpath,'waypoints'))\n",
+    "vector_size = tixi_h.getVectorSize('/'.join((root_xpath,'waypoints')))\n",
     "\n",
-    "waypoints = tixi_h.getTextElement(os.path.join(root_xpath,'waypoints')).split(';')\n",
-    "latitude = tixi_h.getFloatVector(os.path.join(root_xpath,'latitude'),vector_size)\n",
-    "longitude = tixi_h.getFloatVector(os.path.join(root_xpath,'longitude'),vector_size)\n",
+    "waypoints = tixi_h.getTextElement('/'.join((root_xpath,'waypoints'))).split(';')\n",
+    "latitude = tixi_h.getFloatVector('/'.join((root_xpath,'latitude')), vector_size)\n",
+    "longitude = tixi_h.getFloatVector('/'.join((root_xpath,'longitude')), vector_size)\n",
     "\n",
-    "for i, wp in enumerate(waypoints): print('%10s %.3f %.3f'%(wp, latitude[i], longitude[i]))"
+    "for i, wp in enumerate(waypoints):\n",
+    "    print('%10s %.3f %.3f'%(wp, latitude[i], longitude[i]))"
    ]
   },
   {
@@ -123,7 +122,7 @@
     "\n",
     "tixi_h.createElementAtIndex(apts_xpath,'airport',idx)\n",
     "\n",
-    "apt_xpath = os.path.join(apts_xpath,'airport[%i]'%idx)\n",
+    "apt_xpath = '/'.join((apts_xpath,'airport[%i]'%idx))\n",
     "\n",
     "tixi_h.addTextAttribute(apt_xpath,'uID','BWE')\n",
     "tixi_h.addTextElement(apt_xpath, 'name', 'Braunschweig, Germany')\n",
@@ -148,13 +147,6 @@
     "tixi_h.save('D150_v30_modified.xml')\n",
     "tixi_h.close()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
The XPaths in the Tixi examples are invalid on windows due to backslashed being used by os.path.join. Therefore os.path.join(a, b) has been replaced with '/'.join((a, b))