### PR TITLE
Updating import statement

### DIFF
--- a/Notebooks/Tigl_Basic/tigl_exercise1_basics.ipynb
+++ b/Notebooks/Tigl_Basic/tigl_exercise1_basics.ipynb
@@ -191,7 +191,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from OCC.BRepPrimAPI import BRepPrimAPI_MakeBox\n",
+    "from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakeBox\n",
     "box = BRepPrimAPI_MakeBox(0.3, 0.8, 0.3).Solid()"
    ]
   },


### PR DESCRIPTION
Changing import statement in "tigl_exercise1_basics.ipynb" codecell 42:

"OCC.BRepPrimAPI" ->"OCC.Core.BRepPrimAPI"

Solves ModuleNotFoundError: "BRepPrimAPI_MakeBox"ModuleNotFoundError: No module named 'OCC.BRepPrimAPI'"